### PR TITLE
Changed brawl colors

### DIFF
--- a/src/components/Brawl/index.js
+++ b/src/components/Brawl/index.js
@@ -212,7 +212,7 @@ const Stories = ({ setActive }) => {
           <Banner
             className='Brawl__section'
             key={brawl.name}
-            faction={'swarm'}
+            faction={brawl.faction}
             title={brawl.name}
             copy={
               <>
@@ -227,7 +227,7 @@ const Stories = ({ setActive }) => {
                     is likely the way to go when trying to reach higher ranks.
                   </>
                 ) : (
-                  ' Most factions are likely to compete in that Brawl, where there no clear winner.'
+                  ' Most factions are likely to compete in that Brawl, where there is no clear winner.'
                 )}
               </>
             }


### PR DESCRIPTION
+ I'm not sure this is intended, but all the brawl banners have the same color - that of swarm. This provides a quick fix by replacing swarm by brawl.faction - if this one is null, the default color will be chosen. If it's intended I'll revert it.
+ Corrected a small typo
