### PR TITLE
Fixed a test where playing First Mutineer leaves only 2 cards in hand

### DIFF
--- a/cypress/integration/deckBuilder/dryRun.js
+++ b/cypress/integration/deckBuilder/dryRun.js
@@ -21,7 +21,7 @@ const isMarkedAffordable = $card => {
 
 describe('Deck Builder — Dry-run', () => {
   const CHEAP_DECK =
-    'NU4xLDVOMiw1RjMsNU4zLDVONCw0TjUsNE42LDJONjIsMk42NywyTjY2LDVOMTIsNU4xNg=='
+    'NU4xLDVOMiw1RjMsNU4zLDVONCw0TjUsNE42LDJONjIsMk42NywyTjY2LDVONjMsNU4xNg=='
   const EXPENSIVE_DECK =
     'Mk42OCw0TjQ3LDNONDgsNE40OSwyTjUwLDNONTEsNE41MiwzTjUzLDVONTQsMk41NSwyTjU2LDNONTc='
 


### PR DESCRIPTION
The Cheap deck contained First Mutineer, which would discard a card when played, failing the test that checked that 3 cards remained in hand. Fixed by replacing First Mutineer by Unhealthy Hysteria