### PR TITLE
FAQ Table of Contents bug fix

### DIFF
--- a/src/components/FAQ/index.js
+++ b/src/components/FAQ/index.js
@@ -21,10 +21,15 @@ const FAQ = () => {
     if (!hash) return
     const node = document.querySelector(hash)
     if (node) node.scrollIntoView()
+
+    const requestedId = hash.slice(1)
     const category = categories.find(
-      cat => !!cat.entries.find(entry => entry.id === hash.slice(1))
+      cat =>
+        cat.id === requestedId ||
+        cat.entries.find(entry => entry.id === requestedId)
     )
-    if (!expanded.includes(category.id)) {
+
+    if (category && !expanded.includes(category.id)) {
       setExpanded(ids => [...ids, category.id])
     }
     //eslint-disable-next-line


### PR DESCRIPTION
When selecting a category in the table of contents the website would crash because category was only checked in the entries. Added a fix to expand the selected category