### PR TITLE
Shuffle spells for Archdruid Earyn

### DIFF
--- a/src/components/DeckMechanisms/handleCardEffect.js
+++ b/src/components/DeckMechanisms/handleCardEffect.js
@@ -1,6 +1,7 @@
 import { PROBABILITIES } from '../../constants/dryRunner'
 import arrayRandom from '../../helpers/arrayRandom'
 import resolveCardForLevel from '../../helpers/resolveCardForLevel'
+import shuffle from '../../helpers/shuffle'
 import play from './play'
 import cycle from './cycle'
 import draw from './draw'
@@ -192,12 +193,13 @@ const handleCardEffect = (state, card, mode) => {
     // Archdruid Earyn
     case 'N48': {
       const spells = state.hand.filter(getPlayableSpells(state))
+      const shuffledSpells = shuffle(spells)
 
       if (mode !== 'MANUAL' && spells.length > 0) {
-        play(state, spells[0], { mode, free: true })
+        play(state, shuffledSpells[0], { mode, free: true })
 
         if (card.level >= 4 && spells.length > 1) {
-          play(state, spells[1], { mode, free: true })
+          play(state, shuffledSpells[1], { mode, free: true })
         }
       }
       break


### PR DESCRIPTION
Archdruid always plays the first two spells in the hand, its random ability is only based on draw order. Since some cards can be kept in hand for different reasons and to match game behavior I've added a shuffle