### PR TITLE
Fix coins for lvl 5 cards not displaying

### DIFF
--- a/src/components/BookOutcome/index.js
+++ b/src/components/BookOutcome/index.js
@@ -17,7 +17,7 @@ const useExpectedCoins = book => {
   const collectionWithRarity = React.useMemo(
     () =>
       collection.map(card => {
-        card.rarity = getRawCardData(card).rarity
+        card.rarity = getRawCardData(card.id).rarity
         return card
       }),
     [collection]


### PR DESCRIPTION
Right now `card.rarity` is set to undefined and the max cards per rarity are not counted, causing the expected coins to be set to 0 and the "No coins" message to be shown. Found the issue to be in the fact that getRawCardData takes an id and the (new?) collection data contains cards