### PR TITLE
Add a check for inefficient High-Priestess Klaxi

### DIFF
--- a/cypress/integration/deckBuilder/advice.js
+++ b/cypress/integration/deckBuilder/advice.js
@@ -53,6 +53,12 @@ describe('Deck Builder — Advice', () => {
       .should('be.visible')
   })
 
+  it('should warn about inefficient High Priestess Klaxi', () => {
+    cy.visit('/deck/1f41n81n611n181n91n251f131n311n341n361n381f23')
+      .get('#INEFFICIENT_HIGH_PRIESTESS_KLAXI')
+      .should('be.visible')
+  })
+
   it('should warn about lack of AoE', () => {
     cy.visit('/deck/1n11n21n31n671n71n101n201i141n651n271i281n76/detail')
       .get('#LACK_OF_AOE')

--- a/cypress/integration/deckBuilder/advice.js
+++ b/cypress/integration/deckBuilder/advice.js
@@ -54,7 +54,7 @@ describe('Deck Builder — Advice', () => {
   })
 
   it('should warn about inefficient High Priestess Klaxi', () => {
-    cy.visit('/deck/1f41n81n611n181n91n251f131n311n341n361n381f23')
+    cy.visit('/deck/1f41n81n611n181n91n251f131n311n341n361n381f23/detail')
       .get('#INEFFICIENT_HIGH_PRIESTESS_KLAXI')
       .should('be.visible')
   })

--- a/src/components/DeckAdvice/index.js
+++ b/src/components/DeckAdvice/index.js
@@ -144,6 +144,9 @@ const getSuggestions = cards => {
     c => c.id !== 'N13' && c.id !== 'I5' && c.id !== 'I14'
   )
   const hasLinkedGolems = cards.map(c => c.id).includes('I8')
+  const hasHighPriestessKlaxi = cards.map(c => c.id).includes('F23')
+  const hasRainOfFrogs = cards.map(c => c.id).includes('F8')
+  const hasAzureHatchers = cards.map(c => c.id).includes('F10')
   const constructs = getConstructs(cards)
   const oddManaCards = getOddManaCards(cards)
   const evenManaCards = getEvenManaCards(cards)
@@ -254,6 +257,16 @@ const getSuggestions = cards => {
         description:
           'This deck includes Linked Golems but doesn’t include enough constructs to provide good synergy. Consider including more constructs.',
         highlight: () => ['I8'],
+      },
+
+    hasHighPriestessKlaxi &&
+      !hasRainOfFrogs &&
+      !hasAzureHatchers && {
+        id: 'INEFFICIENT_HIGH_PRIESTESS_KLAXI',
+        name: 'Undervalued High Priestess Klaxi',
+        description:
+          'This deck includes High Priestess Klaxi but doesn’t include a way to spawn many units of the same strength. Consider including Rain of Frogs or Azure Hatchers.',
+        highlight: () => ['F23', 'F8', 'F10'],
       },
   ].filter(Boolean)
 }


### PR DESCRIPTION
Added inefficient High Priestess Klaxi to deck advice and test.