### PR TITLE
Add Rockworkers in Hearthguards deck advice

### DIFF
--- a/src/helpers/getDeckAdvice/advice/HEARTHGUARDS/index.js
+++ b/src/helpers/getDeckAdvice/advice/HEARTHGUARDS/index.js
@@ -1,7 +1,7 @@
 const getStructures = cards => cards.filter(c => c.type === 'structure')
 // Construction workers not considered for now; May be added later.
 const structureSpawningCardIds = new Set([
-  "W13",  // Hearthguards
+  "W13",  // Rockworkers
 ])
 const getStructureSpawningCards = cards => cards.filter(c => structureSpawningCardIds.has(c.id))
 

--- a/src/helpers/getDeckAdvice/advice/HEARTHGUARDS/index.js
+++ b/src/helpers/getDeckAdvice/advice/HEARTHGUARDS/index.js
@@ -1,7 +1,12 @@
 const getStructures = cards => cards.filter(c => c.type === 'structure')
+// Construction workers not considered for now; May be added later.
+const structureSpawningCardIds = new Set([
+  "W13",  // Hearthguards
+])
+const getStructureSpawningCards = cards => cards.filter(c => structureSpawningCardIds.has(c.id))
 
 export default cards => {
-  const structures = getStructures(cards)
+  const structures = [...getStructures(cards), ...getStructureSpawningCards(cards)]
   const cheapStructures = structures.filter(card => card.mana <= 3)
   const cardIds = cards.map(card => card.id)
   const hasHearthguards = cardIds.includes('N39')

--- a/src/helpers/getDeckAdvice/advice/HEARTHGUARDS/spec.js
+++ b/src/helpers/getDeckAdvice/advice/HEARTHGUARDS/spec.js
@@ -19,6 +19,11 @@ describe('The `HEARTHGUARDS` advice', () => {
     expect(advice(cards)).to.equal(null)
   })
 
+  it('should not be returned if it has at least 1 structure and Rockworkers', () => {
+    const cards = getCards('1xn1w1n2n66w2n3w4w7w13n34n39w17')
+    expect(advice(cards)).to.equal(null)
+  })
+
   it('should not be returned if it has a cheap structure', () => {
     const cards = getCards('5n15n25i15n31n45n65i55i75n185i135i205n39')
     expect(advice(cards)).to.equal(null)
@@ -26,6 +31,11 @@ describe('The `HEARTHGUARDS` advice', () => {
 
   it('should be returned if there are not enough structures', () => {
     const cards = getCards('1n11i11i21n671n661n641n651i161i171n341n391n68')
+    expect(advice(cards)).to.not.equal(null)
+  })
+
+  it('should be returned if there are not enough structures, including Rockworkers', () => {
+    const cards = getCards('1xn1w1n2n66w2n3w4w7w28w13n39w17')
     expect(advice(cards)).to.not.equal(null)
   })
 


### PR DESCRIPTION
Solves #256 
There can be other things to improve more but hopefully I think they can be done in a separate commit:
- Whether to include Qordia & Construction Workers
- Whether to include Rockworkers (+ the upper two units) in the deck advice message,
    appropriately chosen by deck faction
