### PR TITLE
Added my pirate deck.

### DIFF
--- a/src/data/decks.json
+++ b/src/data/decks.json
@@ -1142,5 +1142,15 @@
       "MIDRANGE"
     ],
     "date": "08/2021"
+  },
+  {
+    "name": "IC pirate",
+    "id": "5xn1i1n3n5n12n14n16i11n19n22n30n42",
+    "author": "Tremjya",
+    "tags": [
+      "HIGH_LEVELS",
+      "RUSH"
+    ],
+    "date": "08/2021"
   }
 ]


### PR DESCRIPTION
Most pirate decks in stormbound kitty is for brawl only. So I added my deck which helped me reach diamond league.